### PR TITLE
Add logical expression to catch missing parameters in the middle of a training command

### DIFF
--- a/ICE/ICE.cpp
+++ b/ICE/ICE.cpp
@@ -70,7 +70,7 @@ void ICE::Init(int dimension) {
 }
 
 
-void ICE::Train(int sample_times, int negative_samples, double alpha, int workers){
+void ICE::Train(int sample_times, int negative_samples, double alpha, double alpha_min, int workers){
     
     omp_set_num_threads(workers);
 
@@ -86,8 +86,8 @@ void ICE::Train(int sample_times, int negative_samples, double alpha, int worker
     cout << "Start Training:" << endl;
 
     unsigned long long total_sample_times = (unsigned long long)sample_times*1000000;
-    double alpha_min = alpha * 0.0001;
-    double alpha_last;
+    double alpha_last, alpha_reduce;
+    alpha_reduce = (alpha-alpha_min)*(MONITOR/total_sample_times);
     
     unsigned long long current_sample = 0;
     unsigned long long jobs = total_sample_times/workers;
@@ -108,7 +108,7 @@ void ICE::Train(int sample_times, int negative_samples, double alpha, int worker
             count++;
             if (count % MONITOR == 0)
             {
-                _alpha = alpha* ( 1.0 - (double)(current_sample)/total_sample_times );
+                _alpha = _alpha - alpha_reduce;
                 current_sample += MONITOR;
                 if (_alpha < alpha_min) _alpha = alpha_min;
                 alpha_last = _alpha;

--- a/ICE/ICE.cpp
+++ b/ICE/ICE.cpp
@@ -87,7 +87,7 @@ void ICE::Train(int sample_times, int negative_samples, double alpha, double alp
 
     unsigned long long total_sample_times = (unsigned long long)sample_times*1000000;
     double alpha_last, alpha_reduce;
-    alpha_reduce = (alpha-alpha_min)*(MONITOR/total_sample_times);
+    alpha_reduce = (alpha-alpha_min)/(total_sample_times/MONITOR);
     
     unsigned long long current_sample = 0;
     unsigned long long jobs = total_sample_times/workers;
@@ -108,7 +108,7 @@ void ICE::Train(int sample_times, int negative_samples, double alpha, double alp
             count++;
             if (count % MONITOR == 0)
             {
-                _alpha = _alpha - alpha_reduce;
+                _alpha -= alpha_reduce;
                 current_sample += MONITOR;
                 if (_alpha < alpha_min) _alpha = alpha_min;
                 alpha_last = _alpha;

--- a/ICE/ICE.h
+++ b/ICE/ICE.h
@@ -29,7 +29,7 @@ class ICE {
         
         // model function
         void Init(int);
-        void Train(int, int, double, int);
+        void Train(int, int, double, double, int);
 
 };
 

--- a/ICE/main.cpp
+++ b/ICE/main.cpp
@@ -1,10 +1,10 @@
-#define _GLIBCXX_USE_CXX11_ABI 0
+#define _GLIBCXX_USE_CXX11_ABI 1
 #include "./ICE.h"
 
 int ArgPos(char *str, int argc, char **argv) {
     int a;
     for (a = 1; a < argc; a++) if (!strcmp(str, argv[a])) {
-        if (a == argc - 1) {
+        if ((a == argc - 1) || (*argv[a+1]=='-')) {
             printf("Argument missing for %s\n", str);
             exit(1);
         }

--- a/ICE/main.cpp
+++ b/ICE/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv){
         printf("\t-alpha <float>\n");
         printf("\t\tInit learning rate; default is 0.025\n");
         printf("\nExample Usage:\n");
-        printf("\t./cli -train network.txt -save rep.txt -dimensions 64 -sample_times 10 -negative_samples 5 -alpha 0.025 -threads 4\n\n");
+        printf("\t./ice -train network.txt -save rep.txt -dim 64 -sample 10 -neg 5 -alpha 0.025 -thread 4\n\n");
         return 0;
     }
     
@@ -66,10 +66,11 @@ int main(int argc, char **argv){
     ice->LoadEdgeList(network_file);
     ice->Init(dimensions);
     
-    int sub_sample_times = sample_times/save_times;
+    int sub_sample_times = sample_times/save_times, current_sample_times=0;
     double alpha_max=init_alpha, alpha_min=init_alpha;
     for (int i=0; i<save_times; ++i)
     {
+        current_sample_times += sub_sample_times;
         alpha_max = alpha_min;
         alpha_min = init_alpha*((double)(save_times-i-1)/save_times);
         if (alpha_min < init_alpha*0.0001) alpha_min = init_alpha*0.0001;
@@ -81,7 +82,7 @@ int main(int argc, char **argv){
         }
         else
         {
-            string sub_rep_file = rep_file + string(".") + to_string(i);
+            string sub_rep_file = rep_file + string(".") + to_string(current_sample_times);
             ice->SaveWeights(sub_rep_file);
         }
     }

--- a/ICE/vvNet.cpp
+++ b/ICE/vvNet.cpp
@@ -702,5 +702,45 @@ void vvNet::UpdatePair(vector< vector<double> >& w_vertex, vector< vector<double
 
 }
 
+void vvNet::UpdateVertex(vector< vector<double> >& w_vertex, vector< vector<double> >& w_context, long vertex, long context, int dimension, int negative_samples, double alpha){
+    
+    vector< double >* w_vertex_ptr;
+    vector< double >* w_context_ptr;
+    vector< double > back_err;
+    back_err.resize(dimension, 0.0);
+
+    int d;
+    long rand_v;
+    double label, g, f, rand_p;
+    
+    label = 1.0;
+    w_vertex_ptr = &w_vertex[vertex];
+    w_context_ptr = &w_context[context];
+
+    negative_samples += 1;
+    // 0 for postive sample, others for negative sample
+    for (int neg=0; neg!=negative_samples; ++neg)
+    {
+        // negative sampling
+        if (neg!=0){
+            label = 0.0;
+            w_context_ptr = &w_context[ NegativeSample() ]; // Negative Sample
+        }
+
+        f = 0;
+        for (d=0; d<dimension; ++d) // prediciton
+            f += (*w_vertex_ptr)[d] * (*w_context_ptr)[d];
+        f = fastSigmoid(f); // fast sigmoid(prediction)
+        g = (label - f) * alpha; // gradient
+        for (d=0; d<dimension; ++d) // store the back propagation error
+            back_err[d] += g * (*w_context_ptr)[d];
+        //for (d=0; d<dimension; ++d) // update context
+        //    (*w_context_ptr)[d] += g * (*w_vertex_ptr)[d];
+    }
+    for (d=0; d<dimension; ++d)
+        (*w_vertex_ptr)[d] += back_err[d];
+
+}
+
 
 

--- a/ICE/vvNet.h
+++ b/ICE/vvNet.h
@@ -112,7 +112,10 @@ class vvNet {
         
         // vertex vector, context vector, vertex, context, dimension, negative samples, alpha
         void UpdatePair(vector< vector<double> >&, vector< vector<double> >&, long, long, int, int, double);
-                
+
+        // vertex vector, context vector, vertex, context, dimension, negative samples, alpha
+        void UpdateVertex(vector< vector<double> >&, vector< vector<double> >&, long, long, int, int, double);
+               
         // vertex vector, context vector, vertex, context, dimension, negative samples, community walk steps, alpha
         void UpdateCommunity(vector< vector<double> >&, vector< vector<double> >&, long, long, int, int, int, double);
 


### PR DESCRIPTION
PROBLEM: The original failsafe feature implemented in main.cpp::ArgPos() can only catch "missing parameter for the LAST flag". E.g. "... -dim 300 -thread". (Notice the parameter for the last flag "-thread" is missing.)

However, the cli is unable to detect parameters missing for flags in the MIDDLE of a command line. E.g. "... -dim -threads 28". (Notice the parameter for the middle flag "-dim" is missing) Furthermore, the program will not use the default value "64" for the flag "-dim" and will use "0" instead.

This is a result of the program does not check to ensure the "next element in the array of arguments", i.e. "argv[i+1]", is not a flag, therefore, mistakes the next flag as parameter for the previous flag and submit a non-number string to the function atoi(), resulting in an error signal, '0', which is mistaken as user-specified dimension size.

SOLUTION: A check for '-' is added after the existing logical expression to ensure the next argument array element is not a flag. The program will now raise a "Argument missing for -flag" error in aforementioned situation.